### PR TITLE
Add daily progression with random events

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,10 @@
                     <span id="treasure-count">0</span>
                     <span>🎁</span>
                 </div>
+                <div class="day-info">
+                    <span id="day-display">Day 1</span>
+                    <span id="step-display">Step 0 / 6</span>
+                </div>
             </div>
         </div>
         
@@ -37,7 +41,7 @@
                 さあ、散歩に出発です！
             </div>
             <div class="choices" id="choices">
-                <button class="choice-btn" onclick="startWalk()">散歩を始める</button>
+                <button class="choice-btn" id="next-btn">Next</button>
             </div>
         </div>
         

--- a/script.js
+++ b/script.js
@@ -696,7 +696,7 @@ document.addEventListener('mouseover', event => {
 });
 
 window.addEventListener('load', () => {
-    startWalk();
+    initDailyWalk();
 });
 
 const extraEvents = {
@@ -738,3 +738,101 @@ const extraEvents = {
 };
 
 Object.assign(events, extraEvents);
+
+// --- Daily walk progression system ---
+
+const eventPool = [
+    { title: "Flower Field", description: "Beautiful flowers are blooming", icon: "🌼" },
+    { title: "Mysterious Alley", description: "A passerby told you about a suspicious shadow", icon: "🕵️" },
+    { title: "Quiet Shrine", description: "You hear distant bells ringing", icon: "🔔" },
+    { title: "Riverside Walk", description: "The water sparkles in the sun", icon: "🌊" },
+    { title: "Bustling Market", description: "Vendors shout cheerful greetings", icon: "🛍️" },
+    { title: "Hilltop View", description: "The town looks tiny from up here", icon: "⛰️" },
+    { title: "Cozy Cafe", description: "The smell of fresh coffee fills the air", icon: "☕" },
+    { title: "Old Library", description: "Dusty books whisper forgotten tales", icon: "📚" },
+    { title: "Sunny Plaza", description: "Children play happily under the sun", icon: "☀️" },
+    { title: "Whispering Woods", description: "The leaves rustle with secrets", icon: "🌲" },
+    { title: "Hidden Garden", description: "A gate opens to a sea of blossoms", icon: "🌷" },
+    { title: "Seaside Pier", description: "Waves crash softly against the pier", icon: "⚓" },
+    { title: "Starry Observatory", description: "You peek through a telescope at distant stars", icon: "🌠" },
+    { title: "Foggy Moor", description: "Mist curls around your feet", icon: "🌫️" },
+    { title: "Rustic Farm", description: "Animals greet you with curious eyes", icon: "🐄" },
+    { title: "Lively Festival", description: "Music and laughter fill the streets", icon: "🎉" },
+    { title: "Deserted Playground", description: "The swings creak in the wind", icon: "🛝" },
+    { title: "Antique Shop", description: "Every shelf holds a story", icon: "🪑" },
+    { title: "Mountain Trail", description: "You hike along a winding path", icon: "🥾" },
+    { title: "Sakura Park", description: "Petals dance in a gentle breeze", icon: "🌸" },
+    { title: "Moonlight Beach", description: "The moon paints silver on the waves", icon: "🌙" },
+    { title: "Silent Station", description: "An empty platform waits patiently", icon: "🚉" },
+    { title: "Secret Cave", description: "Cool air flows from the darkness", icon: "🕳️" },
+    { title: "Floating Bridge", description: "The bridge gently sways over the river", icon: "🌉" },
+    { title: "Lantern Street", description: "Lanterns glow warmly overhead", icon: "🏮" },
+    { title: "Crystal Lake", description: "The water is clear enough to mirror the sky", icon: "💧" },
+    { title: "Windy Meadow", description: "Tall grass waves like the sea", icon: "🍃" },
+    { title: "Golden Temple", description: "Sunlight glints off golden roofs", icon: "🛕" },
+    { title: "Snowy Path", description: "Fresh snow crunches underfoot", icon: "❄️" },
+    { title: "Panda Forest", description: "A panda munches lazily on bamboo", icon: "🐼" }
+];
+
+function shuffle(array) {
+    return array.sort(() => Math.random() - 0.5);
+}
+
+let currentDay;
+let currentStep;
+let todayEvents;
+
+function loadProgress() {
+    currentDay = parseInt(localStorage.getItem('currentDay')) || 1;
+    currentStep = parseInt(localStorage.getItem('currentStep')) || 0;
+    try {
+        todayEvents = JSON.parse(localStorage.getItem('todayEvents')) || [];
+    } catch (e) {
+        todayEvents = [];
+    }
+    if (!Array.isArray(todayEvents) || todayEvents.length < 6) {
+        todayEvents = shuffle([...eventPool]).slice(0, 6);
+    }
+}
+
+function saveProgress() {
+    localStorage.setItem('currentDay', currentDay);
+    localStorage.setItem('currentStep', currentStep);
+    localStorage.setItem('todayEvents', JSON.stringify(todayEvents));
+}
+
+function displayEvent(ev) {
+    document.getElementById('location-icon').textContent = ev.icon || '📍';
+    document.getElementById('location-name').textContent = ev.title;
+    document.getElementById('story-text').textContent = ev.description;
+}
+
+function updateUI() {
+    document.getElementById('day-display').textContent = `Day ${currentDay}`;
+    document.getElementById('step-display').textContent = `Step ${currentStep} / 6`;
+    document.getElementById('progress-fill').style.width = `${(currentStep / 6) * 100}%`;
+}
+
+function nextStep() {
+    if (currentStep < 6) {
+        const ev = todayEvents[currentStep];
+        displayEvent(ev);
+        currentStep++;
+        saveProgress();
+        updateUI();
+    } else {
+        currentDay++;
+        currentStep = 0;
+        todayEvents = shuffle([...eventPool]).slice(0, 6);
+        saveProgress();
+        updateUI();
+        displayEvent({ title: "A new day begins", description: "Click Next to start today's walk", icon: "☀️" });
+    }
+}
+
+function initDailyWalk() {
+    loadProgress();
+    updateUI();
+    displayEvent({ title: "Let's take a walk", description: "Press Next to visit the first place", icon: "🚶" });
+    document.getElementById('next-btn').addEventListener('click', nextStep);
+}

--- a/style.css
+++ b/style.css
@@ -54,7 +54,7 @@ body {
     gap: 10px;
 }
 
-.heart-points, .treasure-count {
+.heart-points, .treasure-count, .day-info {
     font-size: 18px;
     font-weight: bold;
     background: rgba(255, 255, 255, 0.5);
@@ -321,7 +321,7 @@ body {
         align-items: center;
     }
     
-    .heart-points, .treasure-count {
+    .heart-points, .treasure-count, .day-info {
         font-size: 16px;
     }
     


### PR DESCRIPTION
## Summary
- show current day and step in UI
- randomize six events from a pool of 30 per day
- persist daily progress with localStorage and `Next` button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68934cea0f4c8330bcf12f3e31361409