### PR TITLE
Ensure uniform four-choice button layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,10 @@
                 さあ、散歩に出発です！
             </div>
             <div class="choices" id="choices">
-                <button class="choice-btn" id="next-btn">次へ</button>
+                <button class="choice-button" id="next-btn">次へ</button>
+                <button class="choice-button" disabled>選択できません</button>
+                <button class="choice-button" disabled>選択できません</button>
+                <button class="choice-button" disabled>選択できません</button>
             </div>
         </div>
         
@@ -60,15 +63,20 @@
         <div class="diary-screen" id="diary-screen" style="display: none;">
             <h2>📖 今日の散歩日記</h2>
             <div class="diary-content" id="diary-content"></div>
-            <button class="choice-btn" onclick="showTreasureCollection()">宝物コレクション</button>
-            <button class="choice-btn" onclick="restartGame()">また散歩する</button>
+            <button class="choice-button" onclick="showTreasureCollection()">宝物コレクション</button>
+            <button class="choice-button" onclick="restartGame()">また散歩する</button>
+            <button class="choice-button" disabled>選択できません</button>
+            <button class="choice-button" disabled>選択できません</button>
         </div>
         
         <!-- 宝物コレクション画面 -->
         <div class="treasure-collection" id="treasure-collection" style="display: none;">
             <h2>🎁 宝物コレクション</h2>
             <div class="collection-grid" id="collection-grid"></div>
-            <button class="choice-btn" onclick="backToDiary()">日記に戻る</button>
+            <button class="choice-button" onclick="backToDiary()">日記に戻る</button>
+            <button class="choice-button" disabled>選択できません</button>
+            <button class="choice-button" disabled>選択できません</button>
+            <button class="choice-button" disabled>選択できません</button>
         </div>
     </div>
 

--- a/script.js
+++ b/script.js
@@ -423,11 +423,23 @@ function showLocation() {
         }
 
         const btn = document.createElement('button');
-        btn.className = 'choice-btn';
+        btn.className = 'choice-button';
         btn.textContent = choice.text;
         btn.onclick = () => handleChoice(choice.action, choice.treasure, choice.next);
         choicesDiv.appendChild(btn);
     });
+
+    addPlaceholderButtons(choicesDiv);
+}
+
+function addPlaceholderButtons(container) {
+    while (container.children.length < 4) {
+        const btn = document.createElement('button');
+        btn.className = 'choice-button';
+        btn.textContent = '選択できません';
+        btn.disabled = true;
+        container.appendChild(btn);
+    }
 }
 
 function handleChoice(action, treasure, nextIndex) {
@@ -496,10 +508,11 @@ function findTreasure(treasureId) {
         choicesDiv.innerHTML = '';
 
         const continueBtn = document.createElement('button');
-        continueBtn.className = 'choice-btn';
+        continueBtn.className = 'choice-button';
         continueBtn.textContent = '次へ進む';
         continueBtn.onclick = () => moveToNextLocation();
         choicesDiv.appendChild(continueBtn);
+        addPlaceholderButtons(choicesDiv);
     }, 2000);
 }
 
@@ -554,10 +567,11 @@ function showEvent(eventName, nextIndex) {
     choicesDiv.innerHTML = '';
 
     const continueBtn = document.createElement('button');
-    continueBtn.className = 'choice-btn';
+    continueBtn.className = 'choice-button';
     continueBtn.textContent = '次へ進む';
     continueBtn.onclick = () => moveToNextLocation(nextIndex);
     choicesDiv.appendChild(continueBtn);
+    addPlaceholderButtons(choicesDiv);
 }
 
 function updateProgress() {
@@ -690,7 +704,7 @@ function restartGame() {
 }
 
 document.addEventListener('mouseover', event => {
-    if (event.target.classList.contains('choice-btn')) {
+    if (event.target.classList.contains('choice-button')) {
         playSound(660);
     }
 });

--- a/style.css
+++ b/style.css
@@ -116,28 +116,22 @@ body {
     margin: 20px 0;
 }
 
-.choice-btn {
-    background: linear-gradient(45deg, #8bc34a, #ffb74d);
-    color: #fff;
+.choice-button {
+    width: 80%;
+    height: 50px;
+    font-size: 16px;
+    margin: 10px auto;
+    display: block;
+    border-radius: 10px;
+    background: linear-gradient(to right, #fbc2eb, #a6c1ee);
+    color: #333;
     border: none;
-    padding: 15px 25px;
-    font-size: 18px;
-    font-weight: bold;
-    border-radius: 25px;
-    cursor: pointer;
-    margin: 5px;
-    transition: all 0.3s ease;
-    box-shadow: 0 0 10px #8bc34a, 0 0 20px #ffb74d;
-    min-width: 150px;
 }
 
-.choice-btn:hover {
-    transform: translateY(-3px);
-    box-shadow: 0 0 20px #8bc34a, 0 0 40px #ffb74d;
-}
-
-.choice-btn:active {
-    transform: translateY(0);
+.choice-button:disabled {
+    background: #ddd;
+    color: #999;
+    cursor: not-allowed;
 }
 
 /* 進捗バー */
@@ -337,10 +331,9 @@ body {
         font-size: 16px;
     }
     
-    .choice-btn {
+    .choice-button {
         font-size: 16px;
         padding: 12px 20px;
-        min-width: 120px;
     }
     
     .collection-grid {


### PR DESCRIPTION
## Summary
- guarantee four choice buttons on every screen, disabling unused slots with "選択できません"
- standardize button appearance and sizing with new `.choice-button` style
- add helper logic to pad choice areas with inactive buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689493738f1c83309a4e43a42d57b213