### PR TITLE
Add background music

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,6 +81,8 @@
     </div>
 
     <!-- 外部JSファイルを読み込む -->
+    <!-- BGM -->
+    <audio id="bgm" src="audio/sanpo.mp3" loop></audio>
     <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -711,6 +711,11 @@ document.addEventListener('mouseover', event => {
 
 window.addEventListener('load', () => {
     initDailyWalk();
+    const bgm = document.getElementById('bgm');
+    if (bgm) {
+        const resumeBgm = () => bgm.play();
+        document.addEventListener('click', resumeBgm, { once: true });
+    }
 });
 
 const extraEvents = {


### PR DESCRIPTION
## Summary
- embed BGM audio element that references `audio/sanpo.mp3`
- start background music on first user interaction after load

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895ee4e8c8083308784e45fc00482ec